### PR TITLE
Load Prism theme CSS

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,3 +1,5 @@
 // custom typefaces
 import "typeface-montserrat"
 import "typeface-merriweather"
+
+require("prismjs/themes/prism-coy.css")


### PR DESCRIPTION
Currently this starter includes `gatsby-remark-prismjs` but doesn't load a theme for it. Loading a theme is [considered a requirement by gatsby-remark-prismjs](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs#required-pick-a-prismjs-theme-or-create-your-own), since without one syntax highlighting doesn't work properly. This causes [confusion](https://www.reddit.com/r/gatsbyjs/comments/eb5bfo/syntax_highlighting_for_clojure/) for new users.

This PR loads the 'Coy' theme, which I think fits in nicely with the aesthetic of the starter.

I'm not sure if this starter is meant to be as minimal as possible or if it's meant to provide a best-practices starting point. If the latter, I think we should also include the [line highlighting styles](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs#optional-add-line-highlighting-styles), [line numbering styles](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs#optional-add-line-numbering), and [fancy shell prompt](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs#optional-add-shell-prompt). These don't require any additional NPM dependencies, but they do slightly increase the footprint of each page. I'm happy to also add these to the starter if people think it's a good idea.